### PR TITLE
Add authentication options parameter

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -60,9 +60,10 @@ util.inherits(Strategy, OAuthStrategy);
  * Authenticate request by delegating to Intuit using OAuth.
  *
  * @param {Object} req
+ * @param {Object} [options]
  * @api protected
  */
-Strategy.prototype.authenticate = function(req) {
+Strategy.prototype.authenticate = function(req, options) {
   // When Intuit redirects the user back to the application, they include two
   // extra query parameters: `realmId` and `dataSource`.  We stash them away
   // now so that we can attach them to the user profile later.
@@ -70,7 +71,7 @@ Strategy.prototype.authenticate = function(req) {
   this._dataSource = req.query.dataSource;
   
   // Call the base class for standard OAuth authentication.
-  OAuthStrategy.prototype.authenticate.call(this, req);
+  OAuthStrategy.prototype.authenticate.call(this, req, options);
 }
 
 /**


### PR DESCRIPTION
Added the `options` parameter on the `authenticate` method, inherited from [OAuthStrategy.authenticate](https://github.com/jaredhanson/passport-oauth1/blob/master/lib/strategy.js#L117)