### PR TITLE
Collect current user information as part of OAuth profile.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -92,7 +92,23 @@ Strategy.prototype.userProfile = function(token, tokenSecret, params, done) {
   profile.realmId = this._realmId;
   profile.dataSource = this._dataSource;
 
-  return done(null, profile);
+  var xml2js = require('xml2js');
+  this._oauth.get('https://appcenter.intuit.com/api/v1/user/current', token, tokenSecret, function(e, xml){
+      if (e) return done(e);
+      xml2js.parseString(xml, function(e, jsObj){
+        // TODO: Handle jsObj.UserResponse.ErrorCode
+        var userResponse = jsObj ? jsObj.UserResponse : null;
+        if (userResponse && (!userResponse.User || !userResponse.User.length)) e = new Error('Failed to retrieve user information');
+        // Gather information under user.
+        profile.user = {};
+        var currentUser = userResponse.User[0];
+        for (var key in currentUser) {
+          if (key == '$') profile.user.id = currentUser[key].Id;
+          else profile.user[key.toLowerCase()] = (currentUser[key] instanceof Array)? currentUser[key].join(' ') : currentUser[key];
+        }
+        return e? done(e) : done(null, profile);
+      });
+  });
 }
 
 

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -107,7 +107,7 @@ Strategy.prototype.userProfile = function(token, tokenSecret, params, done) {
               if (key == '$') profile.user.id = currentUser[key].Id;
               else profile.user[key.toLowerCase()] = (currentUser[key] instanceof Array)? currentUser[key].join(' ') : currentUser[key];
             }
-            if (typeof profile.isverified == 'string') profile.isverified = (profile.isverified.toLowerCase() == 'true' ? true:false);
+            if (typeof profile.user.isverified == 'string') profile.user.isverified = (profile.user.isverified.toLowerCase() == 'true' ? true:false);
         }
         return e? done(e) : done(null, profile);
       });

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -98,7 +98,7 @@ Strategy.prototype.userProfile = function(token, tokenSecret, params, done) {
       xml2js.parseString(xml, function(e, jsObj){
         // TODO: Handle jsObj.UserResponse.ErrorCode
         var userResponse = jsObj ? jsObj.UserResponse : null;
-        if (userResponse && (!userResponse.User || !userResponse.User.length)) e = new Error('Failed to retrieve user information');
+        if (!e && (!userResponse || !userResponse.User || !userResponse.User.length)) e = new Error('Failed to retrieve user information');
         if (!e) {
             // Gather information under user.
             profile.user = {};

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -99,12 +99,15 @@ Strategy.prototype.userProfile = function(token, tokenSecret, params, done) {
         // TODO: Handle jsObj.UserResponse.ErrorCode
         var userResponse = jsObj ? jsObj.UserResponse : null;
         if (userResponse && (!userResponse.User || !userResponse.User.length)) e = new Error('Failed to retrieve user information');
-        // Gather information under user.
-        profile.user = {};
-        var currentUser = userResponse.User[0];
-        for (var key in currentUser) {
-          if (key == '$') profile.user.id = currentUser[key].Id;
-          else profile.user[key.toLowerCase()] = (currentUser[key] instanceof Array)? currentUser[key].join(' ') : currentUser[key];
+        if (!e) {
+            // Gather information under user.
+            profile.user = {};
+            var currentUser = userResponse.User[0];
+            for (var key in currentUser) {
+              if (key == '$') profile.user.id = currentUser[key].Id;
+              else profile.user[key.toLowerCase()] = (currentUser[key] instanceof Array)? currentUser[key].join(' ') : currentUser[key];
+            }
+            if (typeof profile.isverified == 'string') profile.isverified = (profile.isverified.toLowerCase() == 'true' ? true:false);
         }
         return e? done(e) : done(null, profile);
       });

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   } ],
   "main": "./lib",
   "dependencies": {
-    "passport-oauth1": "1.x.x"
+    "passport-oauth1": "1.x.x",
+    "xml2js": "0.4.x"
   },
   "devDependencies": {
     "vows": "0.8.x"


### PR DESCRIPTION
profile information prepared for OAuth callback missed current user details.

For email based SSO integration having user (email, isverified) flag is essential.
Added the support for same.

```javascript

passport.use("intuit", new IntuitOAuthStrategy({
    ...
}, function(token, tokenSecret, profile, done){
   if (profile.user.isverified) return done(null, profile.user.emailaddress);
});